### PR TITLE
chore: pass GCP_API_KEY into refresh workflow

### DIFF
--- a/.github/workflows/refresh-prices.yml
+++ b/.github/workflows/refresh-prices.yml
@@ -64,6 +64,10 @@ jobs:
 
       - name: Run refresh
         id: refresh
+        env:
+          # GCP Cloud Billing Catalog API key (restricted to Cloud Billing API).
+          # Without this the GCP fetcher cleanly skips. With it, all 4 clouds refresh.
+          GCP_API_KEY: ${{ secrets.GCP_API_KEY }}
         run: |
           set -euo pipefail
           python scripts/refresh_prices.py --output-summary /tmp/summary.md


### PR DESCRIPTION
Wires the GCP_API_KEY repo secret into the weekly refresh workflow. Closes the 4-cloud refresh loop — GCP was the only cloud not refreshing automatically. After merge, the next manual or scheduled run will populate GCP prices for all 15 SKUs.

Key is restricted on GCP-side to Cloud Billing API only.

Generated with [Claude Code](https://claude.com/claude-code)