### PR TITLE
chore(distribution): refresh server.json + add smithery.yaml + submission checklist

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,77 @@
+# Distribution checklist
+
+Where cloudprice-mcp is listed, and how to submit it to the rest. This file is
+for the maintainer — no end-user content.
+
+## Already listed
+
+- **PyPI** — auto-published via GitHub Actions Trusted Publishing on every
+  tagged release. https://pypi.org/project/cloudprice-mcp/
+- **Glama** — https://glama.ai/mcp/servers/alialbaker/cloudprice-mcp (score
+  badge in README).
+
+## To submit (one-time, ~10 min each)
+
+### 1. Official MCP Registry — `registry.modelcontextprotocol.io`
+
+This is Anthropic's canonical registry, launched late 2025. Smithery and
+PulseMCP are increasingly federating from it.
+
+Prereq: `server.json` lives in the repo root (already there, v0.18.0).
+
+Steps:
+
+1. Install the publisher CLI:
+   ```
+   curl -L https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz
+   sudo mv mcp-publisher /usr/local/bin/
+   ```
+   Windows / macOS: grab the right asset from
+   <https://github.com/modelcontextprotocol/registry/releases>.
+
+2. From the repo root:
+   ```
+   mcp-publisher login github
+   mcp-publisher publish
+   ```
+   The login opens a GitHub OAuth flow in your browser; the publish reads
+   `server.json` and posts it.
+
+3. Future updates: bump `version` in `server.json` to match the new release,
+   then re-run `mcp-publisher publish`.
+
+### 2. Smithery — `smithery.ai`
+
+Prereq: `smithery.yaml` in the repo root (already there).
+
+Steps:
+
+1. Visit <https://smithery.ai/new>.
+2. Sign in with GitHub.
+3. Authorize the Smithery app on `Albaker-Group/cloudprice-mcp`.
+4. Smithery picks up `smithery.yaml` automatically and lists the server.
+5. Future updates auto-deploy on every commit to `main`.
+
+### 3. mcp.so — community directory
+
+GitHub-issue-based submission.
+
+1. Open <https://github.com/chatmcp/mcpso/issues/new/choose>.
+2. Pick "Submit MCP Server".
+3. Fields:
+   - Name: `cloudprice-mcp`
+   - Author: `Ali Albaker`
+   - GitHub: `https://github.com/Albaker-Group/cloudprice-mcp`
+   - Description: copy from `server.json`'s description.
+   - Tags: `finops`, `pricing`, `aws`, `azure`, `gcp`, `oci`, `llm`, `cost`.
+4. Submit. The maintainers review and merge within a few days.
+
+### 4. (Optional) PulseMCP — auto-federates from the official registry
+
+No action needed once step 1 lands; PulseMCP picks it up on its next sync.
+
+### 5. (Optional) Cursor MCP directory
+
+Cursor maintains its own catalog at <https://cursor.directory/mcp>.
+Submission is via the form on the page or via PR to the underlying repo.
+Lower priority than the three above.

--- a/server.json
+++ b/server.json
@@ -2,18 +2,18 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.alialbaker/cloudprice-mcp",
   "title": "Cloudprice",
-  "description": "Compare on-demand compute + storage pricing across AWS, Azure, and GCP. Bulk workload compare.",
+  "description": "The FinOps MCP server. 25 tools for multi-cloud cost + carbon comparison across AWS / Azure / GCP / OCI, plus cross-provider LLM token pricing (~2300 model/provider combinations: Anthropic / OpenAI / Google / Bedrock / Vertex / Azure OpenAI / Together AI / Fireworks / Groq / Replicate / Perplexity / OpenRouter). FOCUS 1.3 export plugs into Vantage / Apptio / Microsoft Cost Mgmt / OpenCost. Weekly auto-refreshed catalogs with dated price-history snapshots.",
   "repository": {
-    "url": "https://github.com/alialbaker/cloudprice-mcp",
+    "url": "https://github.com/Albaker-Group/cloudprice-mcp",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.18.0",
   "websiteUrl": "https://albaker.info",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloudprice-mcp",
-      "version": "0.2.2",
+      "version": "0.18.0",
       "transport": {
         "type": "stdio"
       }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,12 @@
+runtime: "python"
+startCommand:
+  type: "stdio"
+  configSchema:
+    type: "object"
+    properties: {}
+    required: []
+  commandFunction: |-
+    () => ({
+      command: "cloudprice-mcp",
+      args: []
+    })


### PR DESCRIPTION
## Summary
- **server.json refreshed** from the stale v0.2.2 entry → v0.18.0, full 25-tool description, correct `Albaker-Group/cloudprice-mcp` repo URL (was the old `alialbaker/` org). Ready for `mcp-publisher publish` to the official MCP Registry.
- **smithery.yaml added** with a minimal stdio config so Smithery auto-deploys the server once the GitHub app is authorized.
- **docs/DISTRIBUTION.md** is a maintainer-only checklist with exact steps for the three target registries:
  1. Official MCP Registry (`registry.modelcontextprotocol.io`) — Anthropic's canonical registry
  2. Smithery (`smithery.ai`) — 6,000+ servers; auto-federates from official registry
  3. mcp.so — community directory, GitHub-issue submission

## Why this matters
Per the research bucket: distribution is free and these three registries cover ~95% of MCP discovery surface. We've been on Glama + PyPI only.

## What the user (Ali) has to do post-merge
The actual submissions need OAuth flows or GitHub-issue clicks — I can't do them. Each takes ~5-10 min. The checklist in `docs/DISTRIBUTION.md` walks through each one. Recommended order:

1. **Official MCP Registry** first — Smithery + PulseMCP federate from it, so other registries get a discount.
2. **Smithery** second — pure GitHub OAuth, no CLI.
3. **mcp.so** when convenient — just opens a GitHub issue.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: run `mcp-publisher login github && mcp-publisher publish` from the repo root
- [ ] Authorize Smithery GitHub app at https://smithery.ai/new
- [ ] File mcp.so issue at https://github.com/chatmcp/mcpso/issues/new/choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)
